### PR TITLE
Require package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Description: A "define" function is provided that allows
     for inclusion of external scripts without polluting
     the global namespace and makes it easier to
     write modular R code.
-Version: 0.3
+Version: 0.3.1
 Author: Robert Krzyzanowski <technoguyrob@gmail.com>
 Maintainer: Robert Krzyzanowski <technoguyrob@gmail.com>
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Version 0.3.1
 
-  * `pacakges` now brings the package into memory using `require`, which was the pre-0.3 functionality.
+  * `packages` now brings the package into memory using `require`, which was the pre-0.3 functionality.
 
 # Version 0.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 0.3.1
+
+  * `pacakges` now brings the package into memory using `require`, which was the pre-0.3 functionality.
+
 # Version 0.3
 
   * `packages` will now install from GitHub when the package name contains a '/'.

--- a/R/load_package.r
+++ b/R/load_package.r
@@ -34,7 +34,7 @@ load_package <- function(name, verbose = FALSE) {
   if (!package_is_installed(name)) {
     stop(paste("Package", name, "not found on", remote, "."))
   }
-  TRUE
+  require(name, character.only = TRUE)
 }
 
 handle_version_mismatches <- function(name, verbose) {

--- a/tests/testthat/test-load_pacakge.r
+++ b/tests/testthat/test-load_pacakge.r
@@ -100,6 +100,7 @@ describe("it can install from CRAN", {
   with_mock(
     `devtools::install_github` = function(...) { stop("Wrong installer!") },
     `stop` = function(...) { TRUE }, #Avoid crashing since we aren't really installing
+    `require` = function(...) { TRUE },
     `utils::install.packages` = function(...) { "correct installer!" }, {
     test_that("it installs", {
       expect_true(load_package("glmnet"))
@@ -131,6 +132,7 @@ describe("it can install from GitHub", {
       `devtools::install_github` = function(...) { "Correct installer!" },
       `Ramd:::package_is_installed` = function(...) { FALSE },
       `stop` = function(...) { TRUE }, #Avoid crashing since we aren't really installing
+      `require` = function(...) { TRUE },
       `utils::install.packages` = function(...) { stop("Wrong installer!") }, {
         test_that("it installs", {
           expect_true(load_package("robertzk/Ramd"))


### PR DESCRIPTION
Prior to 0.3, `packages` would bring the package into memory using `require`. This was removed in 0.3. 0.3.1 brings this functionality back as old code had depended upon it.